### PR TITLE
Optionally panic on errors in ResourceState.State.

### DIFF
--- a/helper/schema/resource_data.go
+++ b/helper/schema/resource_data.go
@@ -315,6 +315,10 @@ func (d *ResourceData) State() *terraform.InstanceState {
 
 	mapW := &MapFieldWriter{Schema: d.schema}
 	if err := mapW.WriteField(nil, rawMap); err != nil {
+		if d.panicOnError {
+			panic(err)
+		}
+
 		return nil
 	}
 


### PR DESCRIPTION
This extends the `panicOnError` behavior introduced in e93d64b1 to
errors that occur when writing the full attribute set for a ResourceData
value in ResourceState.State.