### PR TITLE
Disable the first panicOnError case.

### DIFF
--- a/helper/schema/resource_data.go
+++ b/helper/schema/resource_data.go
@@ -187,9 +187,10 @@ func (d *ResourceData) Set(key string, value interface{}) error {
 	}
 
 	err := d.setWriter.WriteField(strings.Split(key, "."), value)
-	if err != nil && d.panicOnError {
-		panic(err)
-	}
+	// TODO: uncomment this once [pulumi/pulumi-cloud#56] is solved
+	//if err != nil && d.panicOnError {
+	//	panic(err)
+	//}
 	return err
 }
 


### PR DESCRIPTION
This should prevent false hits of the other case.