### PR TITLE
Support parsing ephemeral variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 1.4.1 (Unreleased)
 
+* Support parsing ephemeral variables [https://github.com/pulumi/terraform/pull/9]
+
 ## 1.4.0 (March 08, 2023)
 
 UPGRADE NOTES:

--- a/main.go
+++ b/main.go
@@ -12,6 +12,9 @@ import (
 
 	"github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/terraform-svchost/disco"
+	"github.com/mattn/go-shellwords"
+	"github.com/mitchellh/cli"
+	"github.com/mitchellh/colorstring"
 	"github.com/pulumi/terraform/pkg/addrs"
 	"github.com/pulumi/terraform/pkg/command/cliconfig"
 	"github.com/pulumi/terraform/pkg/command/format"
@@ -20,9 +23,6 @@ import (
 	"github.com/pulumi/terraform/pkg/logging"
 	"github.com/pulumi/terraform/pkg/terminal"
 	"github.com/pulumi/terraform/version"
-	"github.com/mattn/go-shellwords"
-	"github.com/mitchellh/cli"
-	"github.com/mitchellh/colorstring"
 
 	backendInit "github.com/pulumi/terraform/pkg/backend/init"
 )

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/mitchellh/go-homedir"
 	"github.com/pulumi/terraform/pkg/addrs"
 	"github.com/pulumi/terraform/pkg/command/clistate"
 	"github.com/pulumi/terraform/pkg/command/views"
@@ -24,7 +25,6 @@ import (
 	"github.com/pulumi/terraform/pkg/states/statemgr"
 	"github.com/pulumi/terraform/pkg/terraform"
 	"github.com/pulumi/terraform/pkg/tfdiags"
-	"github.com/mitchellh/go-homedir"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/pkg/backend/remote-state/azure/arm_client.go
+++ b/pkg/backend/remote-state/azure/arm_client.go
@@ -13,9 +13,9 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/hashicorp/go-azure-helpers/authentication"
 	"github.com/hashicorp/go-azure-helpers/sender"
+	"github.com/manicminer/hamilton/environments"
 	"github.com/pulumi/terraform/pkg/httpclient"
 	"github.com/pulumi/terraform/version"
-	"github.com/manicminer/hamilton/environments"
 	"github.com/tombuildsstuff/giovanni/storage/2018-11-09/blob/blobs"
 	"github.com/tombuildsstuff/giovanni/storage/2018-11-09/blob/containers"
 )

--- a/pkg/backend/remote-state/kubernetes/backend.go
+++ b/pkg/backend/remote-state/kubernetes/backend.go
@@ -8,10 +8,10 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/mitchellh/go-homedir"
 	"github.com/pulumi/terraform/pkg/backend"
 	"github.com/pulumi/terraform/pkg/legacy/helper/schema"
 	"github.com/pulumi/terraform/version"
-	"github.com/mitchellh/go-homedir"
 	k8sSchema "k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"

--- a/pkg/backend/remote-state/pg/backend.go
+++ b/pkg/backend/remote-state/pg/backend.go
@@ -5,9 +5,9 @@ import (
 	"database/sql"
 	"fmt"
 
+	"github.com/lib/pq"
 	"github.com/pulumi/terraform/pkg/backend"
 	"github.com/pulumi/terraform/pkg/legacy/helper/schema"
-	"github.com/lib/pq"
 )
 
 const (

--- a/pkg/backend/remote-state/pg/backend_test.go
+++ b/pkg/backend/remote-state/pg/backend_test.go
@@ -9,11 +9,11 @@ import (
 	"os"
 	"testing"
 
+	"github.com/lib/pq"
+	_ "github.com/lib/pq"
 	"github.com/pulumi/terraform/pkg/backend"
 	"github.com/pulumi/terraform/pkg/states/remote"
 	"github.com/pulumi/terraform/pkg/states/statemgr"
-	"github.com/lib/pq"
-	_ "github.com/lib/pq"
 )
 
 // Function to skip a test unless in ACCeptance test mode.

--- a/pkg/backend/remote-state/pg/client.go
+++ b/pkg/backend/remote-state/pg/client.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 
 	uuid "github.com/hashicorp/go-uuid"
+	_ "github.com/lib/pq"
 	"github.com/pulumi/terraform/pkg/states/remote"
 	"github.com/pulumi/terraform/pkg/states/statemgr"
-	_ "github.com/lib/pq"
 )
 
 // RemoteClient is a remote client that stores data in a Postgres database

--- a/pkg/backend/remote/backend.go
+++ b/pkg/backend/remote/backend.go
@@ -16,6 +16,8 @@ import (
 	version "github.com/hashicorp/go-version"
 	svchost "github.com/hashicorp/terraform-svchost"
 	"github.com/hashicorp/terraform-svchost/disco"
+	"github.com/mitchellh/cli"
+	"github.com/mitchellh/colorstring"
 	"github.com/pulumi/terraform/pkg/backend"
 	"github.com/pulumi/terraform/pkg/configs/configschema"
 	"github.com/pulumi/terraform/pkg/logging"
@@ -24,8 +26,6 @@ import (
 	"github.com/pulumi/terraform/pkg/terraform"
 	"github.com/pulumi/terraform/pkg/tfdiags"
 	tfversion "github.com/pulumi/terraform/version"
-	"github.com/mitchellh/cli"
-	"github.com/mitchellh/colorstring"
 	"github.com/zclconf/go-cty/cty"
 
 	backendLocal "github.com/pulumi/terraform/pkg/backend/local"

--- a/pkg/backend/remote/backend_apply_test.go
+++ b/pkg/backend/remote/backend_apply_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	tfe "github.com/hashicorp/go-tfe"
 	version "github.com/hashicorp/go-version"
+	"github.com/mitchellh/cli"
 	"github.com/pulumi/terraform/pkg/addrs"
 	"github.com/pulumi/terraform/pkg/backend"
 	"github.com/pulumi/terraform/pkg/cloud"
@@ -26,7 +27,6 @@ import (
 	"github.com/pulumi/terraform/pkg/terminal"
 	"github.com/pulumi/terraform/pkg/terraform"
 	tfversion "github.com/pulumi/terraform/version"
-	"github.com/mitchellh/cli"
 )
 
 func testOperationApply(t *testing.T, configDir string) (*backend.Operation, func(), func(*testing.T) *terminal.TestOutput) {

--- a/pkg/backend/remote/backend_plan_test.go
+++ b/pkg/backend/remote/backend_plan_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	tfe "github.com/hashicorp/go-tfe"
+	"github.com/mitchellh/cli"
 	"github.com/pulumi/terraform/pkg/addrs"
 	"github.com/pulumi/terraform/pkg/backend"
 	"github.com/pulumi/terraform/pkg/cloud"
@@ -24,7 +25,6 @@ import (
 	"github.com/pulumi/terraform/pkg/states/statemgr"
 	"github.com/pulumi/terraform/pkg/terminal"
 	"github.com/pulumi/terraform/pkg/terraform"
-	"github.com/mitchellh/cli"
 )
 
 func testOperationPlan(t *testing.T, configDir string) (*backend.Operation, func(), func(*testing.T) *terminal.TestOutput) {

--- a/pkg/backend/remote/testing.go
+++ b/pkg/backend/remote/testing.go
@@ -14,6 +14,7 @@ import (
 	svchost "github.com/hashicorp/terraform-svchost"
 	"github.com/hashicorp/terraform-svchost/auth"
 	"github.com/hashicorp/terraform-svchost/disco"
+	"github.com/mitchellh/cli"
 	"github.com/pulumi/terraform/pkg/backend"
 	"github.com/pulumi/terraform/pkg/cloud"
 	"github.com/pulumi/terraform/pkg/configs"
@@ -24,7 +25,6 @@ import (
 	"github.com/pulumi/terraform/pkg/terraform"
 	"github.com/pulumi/terraform/pkg/tfdiags"
 	"github.com/pulumi/terraform/version"
-	"github.com/mitchellh/cli"
 	"github.com/zclconf/go-cty/cty"
 
 	backendLocal "github.com/pulumi/terraform/pkg/backend/local"

--- a/pkg/builtin/provisioners/file/resource_provisioner.go
+++ b/pkg/builtin/provisioners/file/resource_provisioner.go
@@ -7,11 +7,11 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/mitchellh/go-homedir"
 	"github.com/pulumi/terraform/pkg/communicator"
 	"github.com/pulumi/terraform/pkg/configs/configschema"
 	"github.com/pulumi/terraform/pkg/provisioners"
 	"github.com/pulumi/terraform/pkg/tfdiags"
-	"github.com/mitchellh/go-homedir"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/pkg/builtin/provisioners/local-exec/resource_provisioner.go
+++ b/pkg/builtin/provisioners/local-exec/resource_provisioner.go
@@ -9,10 +9,10 @@ import (
 	"runtime"
 
 	"github.com/armon/circbuf"
+	"github.com/mitchellh/go-linereader"
 	"github.com/pulumi/terraform/pkg/configs/configschema"
 	"github.com/pulumi/terraform/pkg/provisioners"
 	"github.com/pulumi/terraform/pkg/tfdiags"
-	"github.com/mitchellh/go-linereader"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/pkg/builtin/provisioners/local-exec/resource_provisioner_test.go
+++ b/pkg/builtin/provisioners/local-exec/resource_provisioner_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pulumi/terraform/pkg/provisioners"
 	"github.com/mitchellh/cli"
+	"github.com/pulumi/terraform/pkg/provisioners"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/pkg/builtin/provisioners/remote-exec/resource_provisioner.go
+++ b/pkg/builtin/provisioners/remote-exec/resource_provisioner.go
@@ -11,12 +11,12 @@ import (
 	"os"
 	"strings"
 
+	"github.com/mitchellh/go-linereader"
 	"github.com/pulumi/terraform/pkg/communicator"
 	"github.com/pulumi/terraform/pkg/communicator/remote"
 	"github.com/pulumi/terraform/pkg/configs/configschema"
 	"github.com/pulumi/terraform/pkg/provisioners"
 	"github.com/pulumi/terraform/pkg/tfdiags"
-	"github.com/mitchellh/go-linereader"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/pkg/builtin/provisioners/remote-exec/resource_provisioner_test.go
+++ b/pkg/builtin/provisioners/remote-exec/resource_provisioner_test.go
@@ -11,10 +11,10 @@ import (
 
 	"strings"
 
+	"github.com/mitchellh/cli"
 	"github.com/pulumi/terraform/pkg/communicator"
 	"github.com/pulumi/terraform/pkg/communicator/remote"
 	"github.com/pulumi/terraform/pkg/provisioners"
-	"github.com/mitchellh/cli"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/pkg/cloud/backend_apply_test.go
+++ b/pkg/cloud/backend_apply_test.go
@@ -15,6 +15,7 @@ import (
 	tfe "github.com/hashicorp/go-tfe"
 	mocks "github.com/hashicorp/go-tfe/mocks"
 	version "github.com/hashicorp/go-version"
+	"github.com/mitchellh/cli"
 	"github.com/pulumi/terraform/pkg/addrs"
 	"github.com/pulumi/terraform/pkg/backend"
 	"github.com/pulumi/terraform/pkg/command/arguments"
@@ -29,7 +30,6 @@ import (
 	"github.com/pulumi/terraform/pkg/terminal"
 	"github.com/pulumi/terraform/pkg/terraform"
 	tfversion "github.com/pulumi/terraform/version"
-	"github.com/mitchellh/cli"
 )
 
 func testOperationApply(t *testing.T, configDir string) (*backend.Operation, func(), func(*testing.T) *terminal.TestOutput) {

--- a/pkg/cloud/backend_plan_test.go
+++ b/pkg/cloud/backend_plan_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	tfe "github.com/hashicorp/go-tfe"
+	"github.com/mitchellh/cli"
 	"github.com/pulumi/terraform/pkg/addrs"
 	"github.com/pulumi/terraform/pkg/backend"
 	"github.com/pulumi/terraform/pkg/command/arguments"
@@ -24,7 +25,6 @@ import (
 	"github.com/pulumi/terraform/pkg/states/statemgr"
 	"github.com/pulumi/terraform/pkg/terminal"
 	"github.com/pulumi/terraform/pkg/terraform"
-	"github.com/mitchellh/cli"
 )
 
 func testOperationPlan(t *testing.T, configDir string) (*backend.Operation, func(), func(*testing.T) *terminal.TestOutput) {

--- a/pkg/cloud/backend_refresh_test.go
+++ b/pkg/cloud/backend_refresh_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mitchellh/cli"
 	"github.com/pulumi/terraform/pkg/backend"
 	"github.com/pulumi/terraform/pkg/command/arguments"
 	"github.com/pulumi/terraform/pkg/command/clistate"
@@ -14,7 +15,6 @@ import (
 	"github.com/pulumi/terraform/pkg/plans"
 	"github.com/pulumi/terraform/pkg/states/statemgr"
 	"github.com/pulumi/terraform/pkg/terminal"
-	"github.com/mitchellh/cli"
 )
 
 func testOperationRefresh(t *testing.T, configDir string) (*backend.Operation, func(), func(*testing.T) *terminal.TestOutput) {

--- a/pkg/cloud/cloud_integration.go
+++ b/pkg/cloud/cloud_integration.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-tfe"
-	"github.com/pulumi/terraform/pkg/backend"
 	"github.com/mitchellh/cli"
+	"github.com/pulumi/terraform/pkg/backend"
 )
 
 // IntegrationOutputWriter is an interface used to to write output tailored for

--- a/pkg/command/console_interactive_solaris.go
+++ b/pkg/command/console_interactive_solaris.go
@@ -6,8 +6,8 @@ package command
 import (
 	"fmt"
 
-	"github.com/pulumi/terraform/pkg/repl"
 	"github.com/mitchellh/cli"
+	"github.com/pulumi/terraform/pkg/repl"
 )
 
 func (c *ConsoleCommand) modeInteractive(session *repl.Session, ui cli.Ui) int {

--- a/pkg/command/console_test.go
+++ b/pkg/command/console_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mitchellh/cli"
 	"github.com/pulumi/terraform/pkg/configs/configschema"
 	"github.com/pulumi/terraform/pkg/providers"
-	"github.com/mitchellh/cli"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/pkg/command/e2etest/main_test.go
+++ b/pkg/command/e2etest/main_test.go
@@ -60,17 +60,6 @@ func setup() func() {
 	}
 }
 
-func canAccessNetwork() bool {
-	// We re-use the flag normally used for acceptance tests since that's
-	// established as a way to opt-in to reaching out to real systems that
-	// may suffer transient errors.
-	return os.Getenv("TF_ACC") != ""
-}
-
 func skipIfCannotAccessNetwork(t *testing.T) {
 	t.Skip("Null provider used in the tests is no longer compatible with this fork of terraform")
-
-	if !canAccessNetwork() {
-		t.Skip("network access not allowed; use TF_ACC=1 to enable")
-	}
 }

--- a/pkg/command/e2etest/main_test.go
+++ b/pkg/command/e2etest/main_test.go
@@ -68,7 +68,7 @@ func canAccessNetwork() bool {
 }
 
 func skipIfCannotAccessNetwork(t *testing.T) {
-	t.Helper()
+	t.Skip("Null provider used in the tests is no longer compatible with this fork of terraform")
 
 	if !canAccessNetwork() {
 		t.Skip("network access not allowed; use TF_ACC=1 to enable")

--- a/pkg/command/format/diff_test.go
+++ b/pkg/command/format/diff_test.go
@@ -5,12 +5,12 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/mitchellh/colorstring"
 	"github.com/pulumi/terraform/pkg/addrs"
 	"github.com/pulumi/terraform/pkg/configs/configschema"
 	"github.com/pulumi/terraform/pkg/lang/marks"
 	"github.com/pulumi/terraform/pkg/plans"
 	"github.com/pulumi/terraform/pkg/states"
-	"github.com/mitchellh/colorstring"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/pkg/command/format/state.go
+++ b/pkg/command/format/state.go
@@ -8,12 +8,12 @@ import (
 
 	"github.com/zclconf/go-cty/cty"
 
+	"github.com/mitchellh/colorstring"
 	"github.com/pulumi/terraform/pkg/addrs"
 	"github.com/pulumi/terraform/pkg/configs/configschema"
 	"github.com/pulumi/terraform/pkg/plans"
 	"github.com/pulumi/terraform/pkg/states"
 	"github.com/pulumi/terraform/pkg/terraform"
-	"github.com/mitchellh/colorstring"
 )
 
 // StateOpts are the options for formatting a state.

--- a/pkg/command/hook_module_install.go
+++ b/pkg/command/hook_module_install.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	version "github.com/hashicorp/go-version"
-	"github.com/pulumi/terraform/pkg/initwd"
 	"github.com/mitchellh/cli"
+	"github.com/pulumi/terraform/pkg/initwd"
 )
 
 type uiModuleInstallHooks struct {

--- a/pkg/command/meta_backend_test.go
+++ b/pkg/command/meta_backend_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mitchellh/cli"
 	"github.com/pulumi/terraform/pkg/addrs"
 	"github.com/pulumi/terraform/pkg/backend"
 	"github.com/pulumi/terraform/pkg/configs"
@@ -17,7 +18,6 @@ import (
 	"github.com/pulumi/terraform/pkg/states"
 	"github.com/pulumi/terraform/pkg/states/statefile"
 	"github.com/pulumi/terraform/pkg/states/statemgr"
-	"github.com/mitchellh/cli"
 	"github.com/zclconf/go-cty/cty"
 
 	backendInit "github.com/pulumi/terraform/pkg/backend/init"

--- a/pkg/command/meta_test.go
+++ b/pkg/command/meta_test.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/mitchellh/cli"
 	"github.com/pulumi/terraform/pkg/backend"
 	"github.com/pulumi/terraform/pkg/backend/local"
 	"github.com/pulumi/terraform/pkg/terraform"
-	"github.com/mitchellh/cli"
 )
 
 func TestMetaColorize(t *testing.T) {

--- a/pkg/command/providers_lock_test.go
+++ b/pkg/command/providers_lock_test.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mitchellh/cli"
 	"github.com/pulumi/terraform/pkg/addrs"
 	"github.com/pulumi/terraform/pkg/depsfile"
 	"github.com/pulumi/terraform/pkg/getproviders"
-	"github.com/mitchellh/cli"
 )
 
 func TestProvidersLock(t *testing.T) {

--- a/pkg/command/providers_schema_test.go
+++ b/pkg/command/providers_schema_test.go
@@ -9,10 +9,10 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/mitchellh/cli"
 	"github.com/pulumi/terraform/pkg/configs/configschema"
 	"github.com/pulumi/terraform/pkg/providers"
 	"github.com/pulumi/terraform/pkg/terraform"
-	"github.com/mitchellh/cli"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/pkg/command/show_test.go
+++ b/pkg/command/show_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/mitchellh/cli"
 	"github.com/pulumi/terraform/pkg/addrs"
 	"github.com/pulumi/terraform/pkg/configs/configschema"
 	"github.com/pulumi/terraform/pkg/plans"
@@ -17,7 +18,6 @@ import (
 	"github.com/pulumi/terraform/pkg/states/statemgr"
 	"github.com/pulumi/terraform/pkg/terraform"
 	"github.com/pulumi/terraform/version"
-	"github.com/mitchellh/cli"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/pkg/command/state_list.go
+++ b/pkg/command/state_list.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/mitchellh/cli"
 	"github.com/pulumi/terraform/pkg/addrs"
 	"github.com/pulumi/terraform/pkg/states"
 	"github.com/pulumi/terraform/pkg/tfdiags"
-	"github.com/mitchellh/cli"
 )
 
 // StateListCommand is a Command implementation that lists the resources

--- a/pkg/command/state_mv.go
+++ b/pkg/command/state_mv.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/mitchellh/cli"
 	"github.com/pulumi/terraform/pkg/addrs"
 	"github.com/pulumi/terraform/pkg/backend"
 	"github.com/pulumi/terraform/pkg/command/arguments"
@@ -12,7 +13,6 @@ import (
 	"github.com/pulumi/terraform/pkg/states"
 	"github.com/pulumi/terraform/pkg/terraform"
 	"github.com/pulumi/terraform/pkg/tfdiags"
-	"github.com/mitchellh/cli"
 )
 
 // StateMvCommand is a Command implementation that shows a single resource.

--- a/pkg/command/state_push.go
+++ b/pkg/command/state_push.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/mitchellh/cli"
 	"github.com/pulumi/terraform/pkg/command/arguments"
 	"github.com/pulumi/terraform/pkg/command/clistate"
 	"github.com/pulumi/terraform/pkg/command/views"
@@ -13,7 +14,6 @@ import (
 	"github.com/pulumi/terraform/pkg/states/statemgr"
 	"github.com/pulumi/terraform/pkg/terraform"
 	"github.com/pulumi/terraform/pkg/tfdiags"
-	"github.com/mitchellh/cli"
 )
 
 // StatePushCommand is a Command implementation that shows a single resource.

--- a/pkg/command/state_push_test.go
+++ b/pkg/command/state_push_test.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mitchellh/cli"
 	"github.com/pulumi/terraform/pkg/backend"
 	"github.com/pulumi/terraform/pkg/backend/remote-state/inmem"
 	"github.com/pulumi/terraform/pkg/states"
-	"github.com/mitchellh/cli"
 )
 
 func TestStatePush_empty(t *testing.T) {

--- a/pkg/command/state_replace_provider.go
+++ b/pkg/command/state_replace_provider.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/mitchellh/cli"
 	"github.com/pulumi/terraform/pkg/addrs"
 	"github.com/pulumi/terraform/pkg/command/arguments"
 	"github.com/pulumi/terraform/pkg/command/clistate"
@@ -11,7 +12,6 @@ import (
 	"github.com/pulumi/terraform/pkg/states"
 	"github.com/pulumi/terraform/pkg/terraform"
 	"github.com/pulumi/terraform/pkg/tfdiags"
-	"github.com/mitchellh/cli"
 )
 
 // StateReplaceProviderCommand is a Command implementation that allows users

--- a/pkg/command/state_rm.go
+++ b/pkg/command/state_rm.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/mitchellh/cli"
 	"github.com/pulumi/terraform/pkg/addrs"
 	"github.com/pulumi/terraform/pkg/command/arguments"
 	"github.com/pulumi/terraform/pkg/command/clistate"
 	"github.com/pulumi/terraform/pkg/command/views"
 	"github.com/pulumi/terraform/pkg/terraform"
 	"github.com/pulumi/terraform/pkg/tfdiags"
-	"github.com/mitchellh/cli"
 )
 
 // StateRmCommand is a Command implementation that shows a single resource.

--- a/pkg/command/state_show.go
+++ b/pkg/command/state_show.go
@@ -5,12 +5,12 @@ import (
 	"os"
 	"strings"
 
+	"github.com/mitchellh/cli"
 	"github.com/pulumi/terraform/pkg/addrs"
 	"github.com/pulumi/terraform/pkg/backend"
 	"github.com/pulumi/terraform/pkg/command/arguments"
 	"github.com/pulumi/terraform/pkg/command/format"
 	"github.com/pulumi/terraform/pkg/states"
-	"github.com/mitchellh/cli"
 )
 
 // StateShowCommand is a Command implementation that shows a single resource.

--- a/pkg/command/state_show_test.go
+++ b/pkg/command/state_show_test.go
@@ -4,11 +4,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mitchellh/cli"
 	"github.com/pulumi/terraform/pkg/addrs"
 	"github.com/pulumi/terraform/pkg/configs/configschema"
 	"github.com/pulumi/terraform/pkg/providers"
 	"github.com/pulumi/terraform/pkg/states"
-	"github.com/mitchellh/cli"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/pkg/command/ui_input.go
+++ b/pkg/command/ui_input.go
@@ -16,9 +16,9 @@ import (
 	"unicode"
 
 	"github.com/bgentry/speakeasy"
-	"github.com/pulumi/terraform/pkg/terraform"
 	"github.com/mattn/go-isatty"
 	"github.com/mitchellh/colorstring"
+	"github.com/pulumi/terraform/pkg/terraform"
 )
 
 var defaultInputReader io.Reader

--- a/pkg/command/unlock.go
+++ b/pkg/command/unlock.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/pulumi/terraform/pkg/states/statemgr"
 
+	"github.com/mitchellh/cli"
 	"github.com/pulumi/terraform/pkg/terraform"
 	"github.com/pulumi/terraform/pkg/tfdiags"
-	"github.com/mitchellh/cli"
 )
 
 // UnlockCommand is a cli.Command implementation that manually unlocks

--- a/pkg/command/unlock_test.go
+++ b/pkg/command/unlock_test.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/pulumi/terraform/pkg/backend/remote-state/inmem"
 	"github.com/mitchellh/cli"
+	"github.com/pulumi/terraform/pkg/backend/remote-state/inmem"
 
 	legacy "github.com/pulumi/terraform/pkg/legacy/terraform"
 )

--- a/pkg/command/untaint_test.go
+++ b/pkg/command/untaint_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/mitchellh/cli"
 	"github.com/pulumi/terraform/pkg/addrs"
 	"github.com/pulumi/terraform/pkg/states"
-	"github.com/mitchellh/cli"
 )
 
 func TestUntaint(t *testing.T) {

--- a/pkg/command/version_test.go
+++ b/pkg/command/version_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/mitchellh/cli"
 	"github.com/pulumi/terraform/pkg/addrs"
 	"github.com/pulumi/terraform/pkg/depsfile"
 	"github.com/pulumi/terraform/pkg/getproviders"
-	"github.com/mitchellh/cli"
 )
 
 func TestVersionCommand_implements(t *testing.T) {

--- a/pkg/command/views/test.go
+++ b/pkg/command/views/test.go
@@ -7,12 +7,12 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/mitchellh/colorstring"
 	"github.com/pulumi/terraform/pkg/command/arguments"
 	"github.com/pulumi/terraform/pkg/command/format"
 	"github.com/pulumi/terraform/pkg/moduletest"
 	"github.com/pulumi/terraform/pkg/terminal"
 	"github.com/pulumi/terraform/pkg/tfdiags"
-	"github.com/mitchellh/colorstring"
 )
 
 // Test is the view interface for the "terraform test" command.

--- a/pkg/command/views/view.go
+++ b/pkg/command/views/view.go
@@ -1,11 +1,11 @@
 package views
 
 import (
+	"github.com/mitchellh/colorstring"
 	"github.com/pulumi/terraform/pkg/command/arguments"
 	"github.com/pulumi/terraform/pkg/command/format"
 	"github.com/pulumi/terraform/pkg/terminal"
 	"github.com/pulumi/terraform/pkg/tfdiags"
-	"github.com/mitchellh/colorstring"
 )
 
 // View is the base layer for command views, encapsulating a set of I/O

--- a/pkg/command/workspace_command_test.go
+++ b/pkg/command/workspace_command_test.go
@@ -7,13 +7,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mitchellh/cli"
 	"github.com/pulumi/terraform/pkg/addrs"
 	"github.com/pulumi/terraform/pkg/backend"
 	"github.com/pulumi/terraform/pkg/backend/local"
 	"github.com/pulumi/terraform/pkg/backend/remote-state/inmem"
 	"github.com/pulumi/terraform/pkg/states"
 	"github.com/pulumi/terraform/pkg/states/statemgr"
-	"github.com/mitchellh/cli"
 
 	legacy "github.com/pulumi/terraform/pkg/legacy/terraform"
 )

--- a/pkg/command/workspace_delete.go
+++ b/pkg/command/workspace_delete.go
@@ -5,13 +5,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
 	"github.com/pulumi/terraform/pkg/command/arguments"
 	"github.com/pulumi/terraform/pkg/command/clistate"
 	"github.com/pulumi/terraform/pkg/command/views"
 	"github.com/pulumi/terraform/pkg/states"
 	"github.com/pulumi/terraform/pkg/tfdiags"
-	"github.com/mitchellh/cli"
-	"github.com/posener/complete"
 )
 
 type WorkspaceDeleteCommand struct {

--- a/pkg/command/workspace_list.go
+++ b/pkg/command/workspace_list.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pulumi/terraform/pkg/tfdiags"
 	"github.com/posener/complete"
+	"github.com/pulumi/terraform/pkg/tfdiags"
 )
 
 type WorkspaceListCommand struct {

--- a/pkg/command/workspace_new.go
+++ b/pkg/command/workspace_new.go
@@ -6,13 +6,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
 	"github.com/pulumi/terraform/pkg/command/arguments"
 	"github.com/pulumi/terraform/pkg/command/clistate"
 	"github.com/pulumi/terraform/pkg/command/views"
 	"github.com/pulumi/terraform/pkg/states/statefile"
 	"github.com/pulumi/terraform/pkg/tfdiags"
-	"github.com/mitchellh/cli"
-	"github.com/posener/complete"
 )
 
 type WorkspaceNewCommand struct {

--- a/pkg/command/workspace_select.go
+++ b/pkg/command/workspace_select.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pulumi/terraform/pkg/tfdiags"
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
+	"github.com/pulumi/terraform/pkg/tfdiags"
 )
 
 type WorkspaceSelectCommand struct {

--- a/pkg/communicator/winrm/communicator.go
+++ b/pkg/communicator/winrm/communicator.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pulumi/terraform/pkg/communicator/remote"
-	"github.com/pulumi/terraform/pkg/provisioners"
 	"github.com/masterzen/winrm"
 	"github.com/packer-community/winrmcp/winrmcp"
+	"github.com/pulumi/terraform/pkg/communicator/remote"
+	"github.com/pulumi/terraform/pkg/provisioners"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/pkg/configs/named_values.go
+++ b/pkg/configs/named_values.go
@@ -35,6 +35,8 @@ type Variable struct {
 
 	DescriptionSet bool
 	SensitiveSet   bool
+	Ephemeral      bool
+	EphemeralSet   bool
 
 	// Nullable indicates that null is a valid value for this variable. Setting
 	// Nullable to false means that the module can expect this variable to
@@ -115,6 +117,12 @@ func decodeVariableBlock(block *hcl.Block, override bool) (*Variable, hcl.Diagno
 		valDiags := gohcl.DecodeExpression(attr.Expr, nil, &v.Sensitive)
 		diags = append(diags, valDiags...)
 		v.SensitiveSet = true
+	}
+
+	if attr, exists := content.Attributes["ephemeral"]; exists {
+		valDiags := gohcl.DecodeExpression(attr.Expr, nil, &v.Ephemeral)
+		diags = append(diags, valDiags...)
+		v.EphemeralSet = true
 	}
 
 	if attr, exists := content.Attributes["nullable"]; exists {
@@ -537,6 +545,9 @@ var variableBlockSchema = &hcl.BodySchema{
 		},
 		{
 			Name: "nullable",
+		},
+		{
+			Name: "ephemeral",
 		},
 	},
 	Blocks: []hcl.BlockHeaderSchema{

--- a/pkg/configs/named_values_test.go
+++ b/pkg/configs/named_values_test.go
@@ -1,0 +1,45 @@
+package configs
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+)
+
+func expectTrue(t *testing.T, condition bool, message string) {
+	t.Helper()
+	if !condition {
+		t.Fatalf("expected true: %s", message)
+	}
+}
+
+func TestParsingEphemeralVariables(t *testing.T) {
+	t.Parallel()
+
+	src := `
+variable "foo_wo" {
+	type = string
+	sensitive = true
+	ephemeral = true
+}`
+
+	fs := afero.NewMemMapFs()
+	if err := afero.WriteFile(fs, "variables.tf", []byte(src), 0600); err != nil {
+		t.Fatalf("unable to write test file: %s", err)
+	}
+
+	parser := NewParser(fs)
+	module, diags := parser.LoadConfigDir(".")
+	if diags.HasErrors() {
+		t.Errorf("unexpected error diagnostics")
+		for _, diag := range diags {
+			t.Logf("- %s", diag)
+		}
+	}
+
+	expectTrue(t, len(module.Variables) == 1, "expected exactly one variable")
+	variable, exists := module.Variables["foo_wo"]
+	expectTrue(t, exists, "variable foo_wo should be present")
+	expectTrue(t, variable.EphemeralSet, "variable foo_wo EphemeralSet should be true")
+	expectTrue(t, variable.Ephemeral, "variable foo_wo Ephemeral should be true")
+}

--- a/pkg/lang/funcs/filesystem_test.go
+++ b/pkg/lang/funcs/filesystem_test.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/pulumi/terraform/pkg/lang/marks"
 	homedir "github.com/mitchellh/go-homedir"
+	"github.com/pulumi/terraform/pkg/lang/marks"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
 	"github.com/zclconf/go-cty/cty/function/stdlib"

--- a/pkg/lang/functions_test.go
+++ b/pkg/lang/functions_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	homedir "github.com/mitchellh/go-homedir"
 	"github.com/pulumi/terraform/pkg/experiments"
 	"github.com/pulumi/terraform/pkg/lang/marks"
-	homedir "github.com/mitchellh/go-homedir"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/pkg/legacy/helper/schema/field_reader_config.go
+++ b/pkg/legacy/helper/schema/field_reader_config.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/pulumi/terraform/pkg/legacy/terraform"
 	"github.com/mitchellh/mapstructure"
+	"github.com/pulumi/terraform/pkg/legacy/terraform"
 )
 
 // ConfigFieldReader reads fields out of an untyped map[string]string to the

--- a/pkg/legacy/helper/schema/field_reader_diff.go
+++ b/pkg/legacy/helper/schema/field_reader_diff.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pulumi/terraform/pkg/legacy/terraform"
 	"github.com/mitchellh/mapstructure"
+	"github.com/pulumi/terraform/pkg/legacy/terraform"
 )
 
 // DiffFieldReader reads fields out of a diff structures.

--- a/pkg/legacy/helper/schema/resource_timeout.go
+++ b/pkg/legacy/helper/schema/resource_timeout.go
@@ -5,9 +5,9 @@ import (
 	"log"
 	"time"
 
+	"github.com/mitchellh/copystructure"
 	"github.com/pulumi/terraform/pkg/configs/hcl2shim"
 	"github.com/pulumi/terraform/pkg/legacy/terraform"
-	"github.com/mitchellh/copystructure"
 )
 
 const TimeoutKey = "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0"

--- a/pkg/legacy/helper/schema/schema.go
+++ b/pkg/legacy/helper/schema/schema.go
@@ -22,10 +22,10 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/pulumi/terraform/pkg/configs/hcl2shim"
-	"github.com/pulumi/terraform/pkg/legacy/terraform"
 	"github.com/mitchellh/copystructure"
 	"github.com/mitchellh/mapstructure"
+	"github.com/pulumi/terraform/pkg/configs/hcl2shim"
+	"github.com/pulumi/terraform/pkg/legacy/terraform"
 )
 
 // Name of ENV variable which (if not empty) prefers panic over error

--- a/pkg/legacy/terraform/resource_test.go
+++ b/pkg/legacy/terraform/resource_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/pulumi/terraform/pkg/configs/configschema"
 	"github.com/zclconf/go-cty/cty"
 
-	"github.com/pulumi/terraform/pkg/configs/hcl2shim"
 	"github.com/mitchellh/reflectwalk"
+	"github.com/pulumi/terraform/pkg/configs/hcl2shim"
 )
 
 func TestResourceConfigGet(t *testing.T) {

--- a/pkg/legacy/terraform/state.go
+++ b/pkg/legacy/terraform/state.go
@@ -22,6 +22,7 @@ import (
 	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/mitchellh/copystructure"
 	"github.com/pulumi/terraform/pkg/addrs"
 	"github.com/pulumi/terraform/pkg/configs"
 	"github.com/pulumi/terraform/pkg/configs/configschema"
@@ -29,7 +30,6 @@ import (
 	"github.com/pulumi/terraform/pkg/plans"
 	"github.com/pulumi/terraform/pkg/tfdiags"
 	tfversion "github.com/pulumi/terraform/version"
-	"github.com/mitchellh/copystructure"
 	"github.com/zclconf/go-cty/cty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
 )

--- a/scripts/staticcheck.sh
+++ b/scripts/staticcheck.sh
@@ -3,7 +3,7 @@
 echo "==> Checking that code complies with static analysis requirements..."
 # Skip legacy code which is frozen, and can be removed once we can refactor the
 # remote backends to no longer require it.
-skip="internal/legacy|backend/remote-state/"
+skip="pkg/legacy|internal/legacy|backend/remote-state/"
 
 # Skip generated code for protobufs.
 skip=$skip"|internal/planproto|internal/tfplugin5|internal/tfplugin6"
@@ -12,7 +12,7 @@ packages=$(go list ./... | egrep -v ${skip})
 
 # We are skipping style-related checks, since terraform intentionally breaks
 # some of these. The goal here is to find issues that reduce code clarity, or
-# may result in bugs. We also disable fucntion deprecation checks (SA1019)
+# may result in bugs. We also disable function deprecation checks (SA1019)
 # because our policy is to update deprecated calls locally while making other
 # nearby changes, rather than to make cross-cutting changes to update them all.
 go run honnef.co/go/tools/cmd/staticcheck -checks 'all,-SA1019,-ST*' ${packages}


### PR DESCRIPTION
In the pulumi-terraform-converter, when we encounter a variable declaration that uses `ephemeral` argument such as
```tf
variable "foo_wo" {
	type = string
	sensitive = true
	ephemeral = true
}
```
We currently fail with the following error
```
Unsupported argument; An argument named "ephemeral" is not expected here.
```
This is because the argument `ephemeral` is not part of the _schema_ we describe in this repo for variable definitions, even though HCL parsers are able to read it. For now we just want to ignore but definitely not error out when encountering such variables as seen in https://github.com/pulumi/pulumi-converter-terraform/issues/387